### PR TITLE
use os.sep to quickly fix linux path

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,7 +3,7 @@ import importlib
 
 NODE_CLASS_MAPPINGS = {}
 
-for node in os.listdir(os.path.dirname(__file__) + '\\nodes'):
+for node in os.listdir(os.path.dirname(__file__) + os.sep + 'nodes'):
     if node.startswith('DT_'):
         node = node.split('.')[0]
         node_import = importlib.import_module('custom_nodes.ComfyUI-Vextra-Nodes.nodes.' + node)


### PR DESCRIPTION
\\ doesn't work on linux. os.sep is os-agnostic

importing pathlib is the usual answer but it's only this one location and os is already imported